### PR TITLE
Add RFC 5424 extractors, update README

### DIFF
--- a/Graylog-OPNsense_Extractors_RFC5424.json
+++ b/Graylog-OPNsense_Extractors_RFC5424.json
@@ -1,7 +1,7 @@
 {
   "extractors": [
     {
-      "title": "OPNsense: IPv4 UDP",
+      "title": "OPNsense: RFC5424 IPv4 UDP",
       "extractor_type": "regex",
       "converters": [
         {
@@ -14,16 +14,16 @@
       ],
       "order": 2,
       "cursor_strategy": "copy",
-      "source_field": "message",
+      "source_field": "full_message",
       "target_field": "filterlog_ipv4_udp",
       "extractor_config": {
-        "regex_value": "^(?i).*\\sfilterlog\\[[0-9]+\\]:\\s(.*)$"
+        "regex_value": "^(?i).*\\sfilterlog.+\\[.+\\]\\s(.*)$"
       },
       "condition_type": "regex",
-      "condition_value": "^(?i).*\\sfilterlog\\[[0-9]+\\]:\\s(.*,(in|out),4,.*,udp,.*)$"
+      "condition_value": "^(?i).*\\sfilterlog.+\\[.+\\]\\s(.*,(in|out),4,.*,udp,.*)$"
     },
     {
-      "title": "OPNsense: IPv4 TCP",
+      "title": "OPNsense: RFC5424 IPv4 TCP",
       "extractor_type": "regex",
       "converters": [
         {
@@ -36,16 +36,16 @@
       ],
       "order": 0,
       "cursor_strategy": "copy",
-      "source_field": "message",
+      "source_field": "full_message",
       "target_field": "filterlog_ipv4_tcp",
       "extractor_config": {
-        "regex_value": "^(?i).*\\sfilterlog\\[[0-9]+\\]:\\s(.*)$"
+        "regex_value": "^(?i).*\\sfilterlog.+\\[.+\\]\\s(.*)$"
       },
       "condition_type": "regex",
-      "condition_value": "^(?i).*\\sfilterlog\\[[0-9]+\\]:\\s(.*,(in|out),4,.*,tcp,.*)$"
+      "condition_value": "^(?i).*\\sfilterlog.+\\[.+\\]\\s(.*,(in|out),4,.*,tcp,.*)$"
     },
     {
-      "title": "OPNsense: IPv6 TCP",
+      "title": "OPNsense: RFC5424 IPv6 TCP",
       "extractor_type": "regex",
       "converters": [
         {
@@ -58,16 +58,16 @@
       ],
       "order": 1,
       "cursor_strategy": "copy",
-      "source_field": "message",
+      "source_field": "full_message",
       "target_field": "filterlog_ipv6_tcp",
       "extractor_config": {
-        "regex_value": "^(?i).*\\sfilterlog\\[[0-9]+\\]:\\s(.*)$"
+        "regex_value": "^(?i).*\\sfilterlog.+\\[.+\\]\\s(.*)$"
       },
       "condition_type": "regex",
-      "condition_value": "^(?i).*\\sfilterlog\\[[0-9]+\\]:\\s(.*,(in|out),6,.*,tcp,.*)$"
+      "condition_value": "^(?i).*\\sfilterlog.+\\[.+\\]\\s(.*,(in|out),6,.*,tcp,.*)$"
     },
     {
-      "title": "OPNsense: IPv4 ICMP",
+      "title": "OPNsense: RFC5424 IPv4 ICMP",
       "extractor_type": "regex",
       "converters": [
         {
@@ -79,16 +79,16 @@
       ],
       "order": 4,
       "cursor_strategy": "copy",
-      "source_field": "message",
+      "source_field": "full_message",
       "target_field": "filterlog_ipv4_icmp",
       "extractor_config": {
-        "regex_value": "^(?i).*\\sfilterlog\\[[0-9]+\\]:\\s(.*)$"
+        "regex_value": "^(?i).*\\sfilterlog.+\\[.+\\]\\s(.*)$"
       },
       "condition_type": "regex",
-      "condition_value": "^(?i).*\\sfilterlog\\[[0-9]+\\]:\\s(.*,(in|out),4,.*,icmp,.*)$"
+      "condition_value": "^(?i).*\\sfilterlog.+\\[.+\\]\\s(.*,(in|out),4,.*,icmp,.*)$"
     },
     {
-      "title": "OPNsense: IPv6 UDP",
+      "title": "OPNsense: RFC5424 IPv6 UDP",
       "extractor_type": "regex",
       "converters": [
         {
@@ -100,16 +100,16 @@
       ],
       "order": 3,
       "cursor_strategy": "copy",
-      "source_field": "message",
+      "source_field": "full_message",
       "target_field": "filterlog_ipv6_udp",
       "extractor_config": {
-        "regex_value": "^(?i).*\\sfilterlog\\[[0-9]+\\]:\\s(.*)$"
+        "regex_value": "^(?i).*\\sfilterlog.+\\[.+\\]\\s(.*)$"
       },
       "condition_type": "regex",
-      "condition_value": "^(?i).*\\sfilterlog\\[[0-9]+\\]:\\s(.*,(in|out),6,.*,udp,.*)$"
+      "condition_value": "^(?i).*\\sfilterlog.+\\[.+\\]\\s(.*,(in|out),6,.*,udp,.*)$"
     },
     {
-      "title": "OPNsense: IPv6 ICMP",
+      "title": "OPNsense: RFC5424 IPv6 ICMP",
       "extractor_type": "regex",
       "converters": [
         {
@@ -121,13 +121,13 @@
       ],
       "order": 5,
       "cursor_strategy": "copy",
-      "source_field": "message",
+      "source_field": "full_message",
       "target_field": "filterlog_ipv6_icmp",
       "extractor_config": {
-        "regex_value": "^(?i).*\\sfilterlog\\[[0-9]+\\]:\\s(.*)$"
+        "regex_value": "^(?i).*\\sfilterlog.+\\[.+\\]\\s(.*)$"
       },
       "condition_type": "regex",
-      "condition_value": "^(?i).*\\sfilterlog\\[[0-9]+\\]:\\s(.*,(in|out),6,.*,icmp,.*)$"
+      "condition_value": "^(?i).*\\sfilterlog.+\\[.+\\]\\s(.*,(in|out),6,.*,icmp,.*)$"
     }
   ],
   "version": "4.2.2"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 # Graylog-OPNsense_Extractors
 Extractors for Graylog to parse OPNsense firewall logs. Should be able to parse most all IPv4/IPv6, ICMP, UDP, & TCP messages.
+
+## Versions
+There are two versions of the extractors, depending on how you have the OPNsense logging destination configured. OPNsense is capable of sending either RFC 5424-compliant logs or more basic syslog messages. The RFC log messages are generally preferred, as they include timezone information (instead of simply sending a bare timestamp in the local system timezone, which Graylog may misintrepret).
+
+The extractors for the two versions are similar, but because Graylog will strip some data from the message as it parses the RFC logs, we must include the full message for the extractor to parse, as detailed below.
+## Usage
+1. Open Graylog. Navigate to the input you wish to run the extractor on.
+2. Click on "Manage extractors". 
+3. Drop down "Actions" in the top right corner, then click "Import extractors"
+4. Paste the contents of the desired JSON file into the box. Click "Add extractors to input"
+5. **If using RFC 5424 logs**: Navigate back to the input, click "More actions' > "Edit input", and ensure "Store full message?" is enabled.
 #
-#
+## Update notes
 6/21/18 Update to IPv6 ICMP. OPNsense sends "ICMPv6", remove case insensitive regex for better processing when under heavy load.
 #
 8/13/19 Update to support OPNsense message format change.
@@ -9,3 +20,5 @@ Extractors for Graylog to parse OPNsense firewall logs. Should be able to parse 
 6/26/21 Update - Removed some ICMP extractors. Updated to new OPNsense log message format.
 #
 12/2/21 Update - Fixed incorrect CSV headers. Removed OPNsense-Unbound_Extractor. 
+
+


### PR DESCRIPTION
When I tried using these extractors in my environment, the timestamps were incorrect (OPNsense was sending timestamps in its local time zone). When I configured OPNsense to send RFC 5424-compliant logs instead, the timestamp issue was fixed, but the extractors could no longer parse the logs, particularly because `filterlog` was now being parsed out into the `application_name` field (and therefore was no longer present in the `message` field). This necessitates instructing Graylog to save the full message, as detailed in the updated README.

I updated the regexes to match the different RFC-compliant format, which looks something like this (example is an IPv6 ICMP message). Note the inclusion of the `meta` structured data ID - this meant changing the regex to match anything in brackets, not just digits:
```
<134>1 2022-07-02T17:21:39-05:00 OPNsense.example.com filterlog 26180 - [meta sequenceId="7293"] 21,,,ecd3a310824625d57c6591b804a0956a,vtnet1,match,block,in,6,0x00,0x00000,1,icmp,1,76,fe80::8599:bc52:987b:b32b,ff02::16,truncated-ip6=76
```

Finally, it appears that OPNsense has switched from sending `ipv6-icmp` to just `icmp`, so I fixed that up as well.

Let me know if there's anything I should address, and thanks for developing these extractors!